### PR TITLE
Update metrics.py

### DIFF
--- a/src/utils/metrics.py
+++ b/src/utils/metrics.py
@@ -48,13 +48,13 @@ def ndcg_(pos_index, pos_len):
     len_rank = np.full_like(pos_len, pos_index.shape[1])
     idcg_len = np.where(pos_len > len_rank, len_rank, pos_len)
 
-    iranks = np.zeros_like(pos_index, dtype=np.float)
+    iranks = np.zeros_like(pos_index, dtype=np.float64)
     iranks[:, :] = np.arange(1, pos_index.shape[1] + 1)
     idcg = np.cumsum(1.0 / np.log2(iranks + 1), axis=1)
     for row, idx in enumerate(idcg_len):
         idcg[row, idx:] = idcg[row, idx - 1]
 
-    ranks = np.zeros_like(pos_index, dtype=np.float)
+    ranks = np.zeros_like(pos_index, dtype=np.float64)
     ranks[:, :] = np.arange(1, pos_index.shape[1] + 1)
     dcg = 1.0 / np.log2(ranks + 1)
     dcg = np.cumsum(np.where(pos_index, dcg, 0), axis=1)
@@ -78,10 +78,10 @@ def map_(pos_index, pos_len):
         \end{align*}
     """
     pre = pos_index.cumsum(axis=1) / np.arange(1, pos_index.shape[1] + 1)
-    sum_pre = np.cumsum(pre * pos_index.astype(np.float), axis=1)
+    sum_pre = np.cumsum(pre * pos_index.astype(np.float64), axis=1)
     len_rank = np.full_like(pos_len, pos_index.shape[1])
     actual_len = np.where(pos_len > len_rank, len_rank, pos_len)
-    result = np.zeros_like(pos_index, dtype=np.float)
+    result = np.zeros_like(pos_index, dtype=np.float64)
     for row, lens in enumerate(actual_len):
         ranges = np.arange(1, pos_index.shape[1]+1)
         ranges[lens:] = ranges[lens - 1]


### PR DESCRIPTION
In the latest version of numpy, np.float has been deprecated, resulting in runtime errors. This PR replaces np.float with float to ensure compatibility.